### PR TITLE
Show aggregate information even when logged in to a job

### DIFF
--- a/clockIn.py
+++ b/clockIn.py
@@ -122,7 +122,6 @@ def display(job):
             minutes='{} {}'.format(minutes, plurality('minute', minutes)),
             seconds='{} {}'.format(seconds, plurality('second', seconds))
         )
-        return to_display
     else:
         to_display += '\nCurrently logged out'
 


### PR DESCRIPTION
This lets you see the aggregate data even if you are currently logged into a job:

### Before
```console
$ python clockIn.py -j 1 -d

Currently logged in on job SweepSouth
Logged in for 0 hours 2 minutes 13 seconds
```

### After
```console
$ python clockIn.py -j 1 -d

Currently logged in on job <JobName>
Logged in for 0 hours 0 minutes 2 seconds
====================
Today:          0 hours  X minutes (R X.XX)
This Month:     0 hours  X minutes (R X.XX)
Last Month:     0 hours  0 minutes (R 0.00)
```